### PR TITLE
Recursively search stdPath for directories

### DIFF
--- a/nimscripter.nimble
+++ b/nimscripter.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.2.0"
+version       = "0.2.1"
 author        = "Jason Beetham"
 description   = "A easy to use Nimscript interop package"
 license       = "MIT"

--- a/src/nimscripter/nimscripter.nim
+++ b/src/nimscripter/nimscripter.nim
@@ -170,9 +170,8 @@ proc loadScript*(script: string, isFile: bool = true, modules: varargs[string],
     let
       scriptName = if isFile: script.splitFile.name else: "script"
     var searchPaths = collect(newSeq):
-        for x in walkDir(stdPath):
-          if x.kind == pcDir:
-            x.path
+        for dir in walkDirRec(stdPath, {pcDir}):
+          dir
     searchPaths.insert stdPath, 0
     let
       intr = createInterpreter(scriptName, searchPaths)

--- a/tests/test.nim
+++ b/tests/test.nim
@@ -37,3 +37,7 @@ suite "nimscripter":
     buff = ""
     1000.addToBuffer(buff)
     check 10000 == intr.get.invoke("doThingExported", buff, int)
+  test "Import deep standard modules":
+    let script = "import sequtils" # stdlib/pure/collections/sequtils.nim
+    let intr = loadScript(script, false)
+    check intr.isSome

--- a/tests/test.nim
+++ b/tests/test.nim
@@ -37,6 +37,10 @@ suite "nimscripter":
     buff = ""
     1000.addToBuffer(buff)
     check 10000 == intr.get.invoke("doThingExported", buff, int)
+  test "Import flat standard modules":
+    let script = "import strutils" # stdlib/pure/strutils.nim
+    let intr = loadScript(script, false)
+    check intr.isSome
   test "Import deep standard modules":
     let script = "import sequtils" # stdlib/pure/collections/sequtils.nim
     let intr = loadScript(script, false)


### PR DESCRIPTION
Currently, nimscripter only considers one level of hierarchy when searching the stdPath for directories. By using `walkDirRec` instead of `walkDir`, nimscripter correctly finds all library folders.