### PR TITLE
`exportTo` macro does not play well with backticks

### DIFF
--- a/nimscripter.nimble
+++ b/nimscripter.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "1.0.8"
+version       = "1.0.9"
 author        = "Jason Beetham"
 description   = "A easy to use Nimscript interop package"
 license       = "MIT"

--- a/src/nimscripter/vmops.nim
+++ b/src/nimscripter/vmops.nim
@@ -20,9 +20,9 @@ proc listDirs(dir: string): seq[string] =
       result.add path
 
 proc rmDir(dir: string, checkDir = false) = removeDir(dir, checkDir)
-proc rmFile(dir: string) = removeFile(dir)
-proc mvDir(`from`, to: string, checkDir = false) = moveDir(`from`, to)
-proc mvFile(`from`, to: string) = moveFile(`from`, to)
+proc rmFile(file: string) = removeFile(file)
+proc mvDir(source, dest: string, checkDir = false) = moveDir(source, dest)
+proc mvFile(source, dest: string) = moveFile(source, dest)
 proc cd(dir: string) = setCurrentDir(dir)
 
 


### PR DESCRIPTION
The exportTo macro does not play well with backticks in the names of proc parameters. 

Using `addVmops` caused `Script Error: (line: 7, col: 12, fileIndex: ...) expected closing ')' to occur anytime any script was loaded.
For some weird reason, the tests were still passing even though the above error was printed. 

I did not investigate it too far. Simply removing the backticks fixed it for now