### PR TITLE
Unable to export non-primitive variables

### DIFF
--- a/nimscripter.nimble
+++ b/nimscripter.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "1.0.13"
+version       = "1.0.14"
 author        = "Jason Beetham"
 description   = "A easy to use Nimscript interop package"
 license       = "MIT"

--- a/src/nimscripter/expose.nim
+++ b/src/nimscripter/expose.nim
@@ -288,7 +288,7 @@ proc generateModuleImpl(n: NimNode, genSym = false): NimNode =
         let
           procName = genSym($n)
           strName = $procName
-          typ = getType(n)
+          typ = getTypeInst(n)
           realName = n
           runCode = quote:
             proc `procName`(): `typ` = discard

--- a/tests/example/objects.nim
+++ b/tests/example/objects.nim
@@ -17,7 +17,7 @@ type
   SomeEnum* {.pure.} = enum
     a, b, c, d
   SomeVarObject* = ref object
-    case kind: SomeEnum
+    case kind*: SomeEnum
     of a:
       b*: float
     of d:

--- a/tests/tgeneral.nim
+++ b/tests/tgeneral.nim
@@ -162,3 +162,41 @@ when isMainModule:
     proc build(): bool
   const addins = implNimscriptModule(buildpackModule)
   discard loadScript(NimScriptFile(script), addins)
+
+test "Export complex variables":
+  let
+    objA = ComplexObject(
+      someInt: -44,
+      someBool: true,
+      someString: "aaa",
+      secondaryBool: true,
+      someOtherString: "bbb"
+    )
+    objB = SomeVarObject(
+      kind: SomeEnum.c,
+      d: "somevar"
+    )
+    objC = RecObject(
+      next: RecObject(
+        next: RecObject(
+          b: {"a":"A", "b":"B"}.toTable()
+        )
+      )
+    )
+    enumA = SomeEnum.c
+
+  const script = """
+assert objA.someInt == -44
+assert objA.someBool == true
+assert objA.someString == "aaa"
+assert objA.secondaryBool == true
+assert objA.someOtherString == "bbb"
+assert enumA == SomeEnum.c
+assert objB.kind == SomeEnum.c
+assert objB.d == "somevar"
+assert objC.next.next.b["a"] == "A"
+assert objC.next.next.b["b"] == "B"
+"""
+  exportTo(objTestModule, SomeEnum, ComplexObject, SomeVarObject, RecObject, enumA, objA, objB, objC)
+  const addins = implNimscriptModule(objTestModule)
+  check loadScript(NimScriptFile(script), addins, modules=["std/tables"]).isSome


### PR DESCRIPTION
Currently, exporting `object` and `enum` fails.
This is because `getType` [here](https://github.com/beef331/nimscripter/blob/adca8fb2810addd0a4817e7d2b389c5cb857fa25/src/nimscripter/expose.nim#L291) returns an object or enum implementation.
By using `getTypeInst` instead, the expected results can be obtained.

example:
```nim
import macros
type MyEnum = enum
  a, b, c
macro m(n: typed) =
  echo n.getType().treeRepr()
  # EnumTy
  #   Empty
  #   Sym "a"
  #   Sym "b"
  #   Sym "c"
  
  echo n.getTypeInst().treeRepr()
  # Sym "MyEnum"

let val = a
m(val)

```

I'm sorry for my poor English.
