### PR TITLE
add test for case objects

### DIFF
--- a/tests/tcaseobjects.nim
+++ b/tests/tcaseobjects.nim
@@ -16,4 +16,5 @@ suite "case object tests":
       testPeg: Peg
     
     echo "testPeg: ", $testPeg
+    check $testPeg == "'hello'"
   

--- a/tests/tcaseobjects.nim
+++ b/tests/tcaseobjects.nim
@@ -1,0 +1,19 @@
+import nimscripter, nimscripter/variables
+import std/unittest
+import std/[strutils, pegs]
+
+suite "case object tests":
+
+  test("test peg"):
+    const script = NimScriptFile dedent"""
+    import pegs
+    let testPeg* = peg"'hello'"
+    """ # Notice `fancyStuff` is exported
+    let intr = loadScript(script) # We are not exposing any procedures hence single parameter
+    # let p1: Peg = intr.invoke(fancyStuff, returnType = Peg) # Calls `fancyStuff(10)` in vm
+    # echo "p1: ", $p1
+    getGlobalNimsVars intr:
+      testPeg: Peg
+    
+    echo "testPeg: ", $testPeg
+  

--- a/tests/tcaseobjects.nims
+++ b/tests/tcaseobjects.nims
@@ -1,0 +1,1 @@
+--expandMacro:fromVmImpl


### PR DESCRIPTION
Test for passing Peg's back from test script. 

```nim
if vmNode.kind == nkNilLit: typeof(obj)(nil)
else:
  let name = fromVm(typeof(string), vmNode.sons[1].sons[1])
  let line = fromVm(typeof(int), vmNode.sons[2].sons[1])
  let col = fromVm(typeof(int), vmNode.sons[3].sons[1])
  let flags = fromVm(typeof(set[NonTerminalFlag]), vmNode.sons[4].sons[1])
  let rule = fromVm(typeof(Peg), vmNode.sons[5].sons[1])
  NonTerminal(name: name, line: line, col: col, flags: flags, rule: rule) [ExpandMacro]

```
